### PR TITLE
Fix localStorage support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,18 @@ export function throttleFn<A extends unknown[], R>(
 }
 
 export default function App() {
-  const [members, setMembers] = useState<Member[]>(initialMembers)
+  const [members, setMembers] = useState<Member[]>(() => {
+    try {
+      const stored = localStorage.getItem('members')
+      if (stored) {
+        const data = JSON.parse(stored)
+        if (Array.isArray(data)) return data as Member[]
+      }
+    } catch {
+      /* ignore */
+    }
+    return initialMembers
+  })
   const [editMode, setEditMode] = useState(false)
   const [selected, setSelected] = useState<MemberStats | null>(null)
   const { width } = useWindowSize()


### PR DESCRIPTION
## Summary
- load previously saved members from localStorage when starting the app

## Testing
- `npx tsc -p tsconfig.json`
- `pnpm lint` *(fails: could not fetch pnpm)*
- `pnpm check` *(fails: could not fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6840008edd748322ac27ffabb687795c